### PR TITLE
Add rasa server and actions server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ docker image rm setup-api
 ```
 
 After that make sure you are in the setup folder and run `docker compose up` which will rebuild the image with the proper packages.
+
+### RASA
+Ensure the rasa server and actions server are both running by executing this post request on your host machine.
+```
+curl --location --request POST 'http://localhost:5005/webhooks/rest/webhook' \
+    --header 'Content-Type: text/plain' \
+    --data-raw '{"message":"faster."}'
+```

--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -15,6 +15,7 @@ services:
     ports:
       - 8000:8000
       - 5678:5678
+
   app:
     build:
       context: ../app
@@ -22,3 +23,23 @@ services:
     #   - ../app/:/app
     ports:
       - 3000:3000
+
+  rasa:
+    image: rasa/rasa:3.3.4-full
+    networks: ['rasa-network']
+    ports:
+    - 5005:5005
+    volumes:
+    - ../RASA-Training/:/app/
+    command: >
+      run --endpoints /app/endpoints-docker.yml
+
+  rasa-actions-server:
+    image: rasa/rasa-sdk:3.4.1
+    networks: ['rasa-network']
+    ports:
+    - 5055:5055
+    volumes:
+    - ../RASA-Training/actions:/app/actions
+
+networks: {rasa-network: {}}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - ../api/:/api
     ports:
       - 8000:8000
+
   app:
     build:
       context: ../app
@@ -17,3 +18,23 @@ services:
       - 3000:3000
     environment:
       - WATCHPACK_POLLING=true
+
+  rasa:
+    image: rasa/rasa:3.3.4-full
+    networks: ['rasa-network']
+    ports:
+    - 5005:5005
+    volumes:
+    - ../RASA-Training/:/app/
+    command: >
+      run --endpoints /app/endpoints-docker.yml
+
+  rasa-actions-server:
+    image: rasa/rasa-sdk:3.4.1
+    networks: ['rasa-network']
+    ports:
+    - 5055:5055
+    volumes:
+    - ../RASA-Training/actions:/app/actions
+
+networks: {rasa-network: {}}


### PR DESCRIPTION
Starts the rasa server and actions server. Instructions to make sure it works are in the readme. Make sure you are also using the **dockerize-rasa** branch of https://github.com/metal-capstone/RASA-Training.